### PR TITLE
fix: propagate dataset captured_at so soc/mileage freshness guard works (Fixes #15)

### DIFF
--- a/custom_components/cupra_eu_data_act/data.py
+++ b/custom_components/cupra_eu_data_act/data.py
@@ -227,6 +227,12 @@ class DataPoint:
     cluster: str | None = None
     timestamp_utc: str | None = None
     sequence: int = 0
+    # Capture moment of the dataset this point came from (its newest
+    # car_captured_time), stamped on every point by ``Dataset.from_json``.
+    # Value fields like soc/mileage carry no per-item ``timestampUtc``, so this
+    # dataset-level stamp is their only freshness signal for cross-dataset
+    # selection in ``find_by_field`` and ``merge_data_points``.
+    captured_at: datetime | None = None
 
     @property
     def value(self):
@@ -283,11 +289,18 @@ class Dataset:
             if field_name.rsplit(".", 1)[-1] in _CAPTURED_TIME_SUFFIXES:
                 if ts := _parse_timestamp(dp.raw_value):
                     captured.append(ts)
+        dataset_captured = max(captured) if captured else None
+        # Stamp the dataset's capture moment onto every point so freshness-based
+        # selection works for value fields (soc, mileage, …) that carry no
+        # per-item timestampUtc of their own.
+        if dataset_captured is not None:
+            for dp in points.values():
+                dp.captured_at = dataset_captured
         return cls(
             vin=payload.get("vin", ""),
             user_id=payload.get("user_id"),
             points=points,
-            captured_at=max(captured) if captured else None,
+            captured_at=dataset_captured,
         )
 
     def by_field(self, field_name: str) -> DataPoint | None:
@@ -302,13 +315,17 @@ def _datapoint_freshness(dp: DataPoint) -> datetime | None:
     """Best-known time a single data point describes, or None if unknown.
 
     Uses the point's own ``timestampUtc`` when present; for captured-time
-    fields the value itself *is* the timestamp.
+    fields the value itself *is* the timestamp. Value fields (soc, mileage, …)
+    carry neither, so fall back to the dataset's car_captured_time stamped onto
+    every point in ``Dataset.from_json`` — without it the freshness guard in
+    ``merge_data_points`` and the ranking in ``find_by_field`` are no-ops for
+    exactly the fields users see regress/oscillate.
     """
     if dp.timestamp:
         return dp.timestamp
     if dp.field_name.rsplit(".", 1)[-1] in _CAPTURED_TIME_SUFFIXES:
         return parse_timestamp(dp.raw_value)
-    return None
+    return dp.captured_at
 
 
 def find_by_field(

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -337,6 +337,61 @@ def main() -> int:
         130,
     )
 
+    # Value fields (soc, mileage) carry no per-item timestampUtc, so their
+    # freshness must come from the dataset's car_captured_time stamped by
+    # from_json. Without it the guards above are no-ops for exactly these
+    # fields and soc oscillates / mileage regresses on a fallback download.
+    print("value-field freshness from dataset captured_at:")
+
+    def _soc_dataset(soc_value, soc_key, car_captured_time):
+        return data.Dataset.from_json(
+            {
+                "vin": "V",
+                "Data": [
+                    {
+                        "key": soc_key,
+                        "dataFieldName": "battery_state_report.soc",
+                        "value": soc_value,
+                    },
+                    {
+                        "key": "cct",
+                        "dataFieldName": "car_captured_time",
+                        "value": car_captured_time,
+                    },
+                ],
+            }
+        )
+
+    newer_ds = _soc_dataset("61", "soc", "2026-01-02T10:00:00Z")
+    older_ds = _soc_dataset("55", "soc", "2026-01-01T10:00:00Z")
+    check(
+        "from_json stamps captured_at on value point",
+        newer_ds.points["soc"].captured_at is not None,
+        True,
+    )
+    # Same UUID key: an older fallback dataset must not regress soc.
+    guarded = data.merge_data_points(dict(newer_ds.points), dict(older_ds.points))
+    check(
+        "older fallback does not regress soc (no per-item ts)",
+        data.find_by_field(guarded, "battery_state_report.soc").value,
+        61,
+    )
+    # Distinct UUID keys lingering in the merged store: the fresher dataset's
+    # reading wins instead of an arbitrary array position.
+    lingering = {
+        "soc-old": _soc_dataset("55", "soc-old", "2026-01-01T10:00:00Z").points[
+            "soc-old"
+        ],
+        "soc-new": _soc_dataset("61", "soc-new", "2026-01-02T10:00:00Z").points[
+            "soc-new"
+        ],
+    }
+    check(
+        "fresher dataset's soc wins among lingering keys",
+        data.find_by_field(lingering, "battery_state_report.soc").value,
+        61,
+    )
+
     print("last_connected_time:")
     sample = json.loads(
         (Path(__file__).parent / "fixtures" / "sample_dataset.json").read_text()


### PR DESCRIPTION
Fixes #15.

### Problem

Value fields (`battery_state_report.soc`, `mileage.value`, flat `state_of_charge` / `mileage`) carry no per-item `timestampUtc`. `_datapoint_freshness()` therefore returned `None` for them, so **both** the `merge_data_points` freshness guard **and** the `find_by_field` ranking were no-ops for exactly the fields users report — SoC oscillates between lingering duplicate keys, and a fallback to an older dataset regresses mileage. This is the integration-side of [mikrohard#24](https://github.com/mikrohard/hass-vw-eu-data-act/issues/24), which the existing guard's comment already references.

### Change (contained to `data.py`)

1. Add `captured_at` to `DataPoint`; in `Dataset.from_json`, stamp the dataset's `car_captured_time` (already computed for `Dataset.captured_at`) onto **every** point.
2. In `_datapoint_freshness`, fall back to `dp.captured_at` when there is no per-item `timestampUtc` / captured-time value.

No call-site changes. The existing no-timestamp **sequence** fallback is preserved: points constructed without a dataset (e.g. unit tests, or genuinely timestamp-less data) still tie on freshness and fall back to last-in-ZIP exactly as before.

### Tests

Adds offline regression coverage in `tests/test_offline.py`, building datasets via `Dataset.from_json` (the real path) to prove the value-field case:

- `from_json` stamps `captured_at` on a value point
- an older fallback dataset does not regress `soc` (no per-item ts)
- the fresher dataset's `soc` wins among lingering duplicate keys

`python tests/test_offline.py`, `test_api_mock.py` and `test_brands.py` all pass locally. (The `pytest`/HA job can't run on my Windows box — HA core needs `fcntl` — but the change is HA-independent and I verified `test_coordinator.py` / `test_config_flow.py` assert nothing on `DataPoint` equality that the new defaulted field would affect.)

### Scope / not in this PR

- This fixes **cross-dataset** regression/oscillation and **duplicate-slot** selection. It does **not** attempt to reorder events **within** a single ZIP — that part of mikrohard#24 is genuinely portal-side.
- The intra-dataset odometer dual-slot (two `mileage.value` readings at the same capture time) is independent; I left a `monotonic`/`prefer_max_value` hardening out of this PR to keep it small, happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
