### PR TITLE
fix: monotonic odometer — prefer the highest mileage slot so it never reads low

### DIFF
--- a/custom_components/cupra_eu_data_act/data.py
+++ b/custom_components/cupra_eu_data_act/data.py
@@ -328,8 +328,15 @@ def _datapoint_freshness(dp: DataPoint) -> datetime | None:
     return dp.captured_at
 
 
+def _as_float(raw) -> float | None:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 def find_by_field(
-    points: dict[str, DataPoint], field_name: str
+    points: dict[str, DataPoint], field_name: str, *, prefer_max_value: bool = False
 ) -> DataPoint | None:
     """Return a single data point for a (possibly duplicated) field name.
 
@@ -341,6 +348,12 @@ def find_by_field(
     When no timestamps distinguish the candidates we use the last occurrence in
     the ZIP. The portal often bundles minute-level snapshots in array order, so
     the last duplicate is the best proxy for the freshest value.
+
+    ``prefer_max_value`` is for monotonic fields (the odometer): one dataset can
+    carry several ``mileage.value`` slots from report snapshots that lag each
+    other (e.g. 70876 vs 70908 at the same capture time), so the **highest**
+    reading is the truest current value. With it set the largest numeric value
+    wins outright; freshness then ZIP position only break exact-value ties.
     """
     matches = [dp for dp in points.values() if dp.field_name == field_name]
     if not matches:
@@ -353,6 +366,15 @@ def find_by_field(
     def rank(dp: DataPoint) -> tuple[bool, datetime]:
         fresh = _datapoint_freshness(dp)
         return (fresh is not None, fresh or _MIN_DT)
+
+    if prefer_max_value:
+        def value_rank(dp: DataPoint):
+            num = _as_float(dp.raw_value)
+            # numeric beats non-numeric, then highest value, then freshest,
+            # then last occurrence in the ZIP
+            return (num is not None, num if num is not None else 0.0, *rank(dp), dp.sequence)
+
+        return max(candidates, key=value_rank)
 
     top = rank(max(candidates, key=rank))
     tied = [dp for dp in candidates if rank(dp) == top]
@@ -752,6 +774,10 @@ class CuratedSensor:
     suggested_display_precision: int | None = None
     # HA entity translation key (name + enum state labels in translations/*.json)
     translation_key: str | None = None
+    # monotonic non-decreasing fields (the odometer): pick the highest of the
+    # duplicate value slots via find_by_field(prefer_max_value=...), so a lagging
+    # report snapshot in the same dataset can't make mileage read low.
+    monotonic: bool = False
 
 
 def curated_translation_key(field_name: str, translation_key: str | None = None) -> str:
@@ -959,6 +985,7 @@ CURATED_SENSORS_DOTTED: tuple[CuratedSensor, ...] = (
         unit_field="mileage.unit",
         unit_resolver="distance",
         suggested_display_precision=0,
+        monotonic=True,
     ),
     CuratedSensor(
         "range.value",
@@ -1238,6 +1265,7 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         "total_increasing",
         icon="mdi:counter",
         suggested_display_precision=0,
+        monotonic=True,
     ),
     CuratedSensor(
         "cruising_range_combined",

--- a/custom_components/cupra_eu_data_act/sensor.py
+++ b/custom_components/cupra_eu_data_act/sensor.py
@@ -244,7 +244,11 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
         ):
             return None
 
-        dp = find_by_field(self.coordinator.data or {}, field_name)
+        dp = find_by_field(
+            self.coordinator.data or {},
+            field_name,
+            prefer_max_value=self._curated.monotonic,
+        )
 
         if not dp:
             return self._sticky(None)

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -392,6 +392,45 @@ def main() -> int:
         61,
     )
 
+    # Monotonic fields (the odometer): one dataset can carry two mileage.value
+    # slots from report snapshots that lag each other. The freshest/last-in-ZIP
+    # default would pick the lower one; prefer_max_value picks the truest (max).
+    print("monotonic odometer prefers the highest duplicate slot:")
+    dual = data.Dataset.from_json(
+        {
+            "vin": "V",
+            "Data": [
+                {"key": "m-hi", "dataFieldName": "mileage.value", "value": "70908"},
+                {"key": "m-lo", "dataFieldName": "mileage.value", "value": "70876"},
+                {
+                    "key": "cct",
+                    "dataFieldName": "car_captured_time",
+                    "value": "2026-01-02T10:00:00Z",
+                },
+            ],
+        }
+    )
+    check(
+        "default picks last-in-ZIP slot",
+        data.find_by_field(dual.points, "mileage.value").value,
+        70876,
+    )
+    check(
+        "prefer_max_value picks highest slot",
+        data.find_by_field(
+            dual.points, "mileage.value", prefer_max_value=True
+        ).value,
+        70908,
+    )
+    check(
+        "mileage curated sensor is flagged monotonic",
+        any(
+            c.field_name == "mileage.value" and c.monotonic
+            for c in data.CURATED_SENSORS_DOTTED
+        ),
+        True,
+    )
+
     print("last_connected_time:")
     sample = json.loads(
         (Path(__file__).parent / "fixtures" / "sample_dataset.json").read_text()


### PR DESCRIPTION
Follow-up to #16 (shipped in v0.6.19). That PR fixed **cross-dataset** freshness for value fields; this one closes the remaining **intra-dataset** odometer case it explicitly left out of scope.

### Problem

A single dataset can carry several `mileage.value` slots from report snapshots that lag each other (e.g. `70876` vs `70908` at the same `car_captured_time`). They share one freshness, so `find_by_field` falls back to last-in-ZIP — which can be the **lower** reading. The odometer then momentarily reads low / non-monotonic. This is the intra-file part of [mikrohard#24](https://github.com/mikrohard/hass-vw-eu-data-act/issues/24).

### Change

- Add a `prefer_max_value` option to `find_by_field`: when set, the largest numeric value wins outright; freshness then ZIP position only break exact-value ties.
- Add a `monotonic` flag to `CuratedSensor`, set on `mileage.value` (dotted) and `mileage` (flat), threaded through the curated resolver in `sensor.py`.

The default `find_by_field` path is untouched — the new branch is only taken when `prefer_max_value=True`, so every non-monotonic sensor behaves exactly as before.

### Tests

Adds offline regression coverage: two `mileage.value` slots in one dataset — the default picks the lower last-in-ZIP `70876`, `prefer_max_value=True` picks `70908`.

`test_offline.py`, `test_api_mock.py` and `test_brands.py` pass locally. (The HA `pytest` job needs Linux/`fcntl`; the change is HA-independent and the curated resolver call site is the only `sensor.py` touch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
