### PR TITLE
feat(tyre): treat 0/1 as invalid for all tyre-pressure families

### DIFF
--- a/custom_components/cupra_eu_data_act/data.py
+++ b/custom_components/cupra_eu_data_act/data.py
@@ -751,7 +751,10 @@ _FIELD_SENTINELS: dict[str, frozenset[float]] = {
 }
 
 # VW tyre-pressure fields encode validity, not pressure: 0 = unsupported,
-# 1 = invalid, otherwise the reading is a pressure value (issue #14).
+# 1 = invalid, otherwise the reading is a pressure value (issue #14). This
+# applies to every tyre-pressure family (actual / required / differential),
+# not just the actual reading. A "required" or "differential" of 0/1 bar is
+# the same unsupported/invalid sentinel, never a real pressure.
 _TYRE_PRESSURE_STATUS_CODES: frozenset[float] = frozenset({0, 1})
 
 
@@ -773,7 +776,7 @@ def is_sentinel(value, field_name: str | None = None) -> bool:
         return True
     if (
         field_name
-        and field_name.startswith("tyre_pressure_actual_")
+        and field_name.startswith("tyre_pressure_")
         and as_float in _TYRE_PRESSURE_STATUS_CODES
     ):
         return True

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -624,9 +624,12 @@ def main() -> int:
         False,
     )
     check(
-        "required tyre pressure 1 bar plausible (issue #33)",
+        # Fork override of issue #33: the portal encodes 0/1 as status codes (0=unsupported,
+        # 1=invalid) for every tyre-pressure family, not just actual. Real pressures are
+        # scaled (e.g. 24 = 2.4 bar), so a "required" of 1 is the invalid sentinel, not 1 bar.
+        "required tyre pressure 1 = invalid sentinel (fork override of issue #33)",
         data.is_sentinel(1, "tyre_pressure_required_front_left"),
-        False,
+        True,
     )
     check(
         "tyre pressure 1 not sentinel without field name",


### PR DESCRIPTION
On this portal the tyre-pressure fields encode validity, not pressure: 0 = unsupported, 1 = invalid, and real pressures arrive scaled (e.g. 24 = 2.4 bar). This widens the existing sentinel check from `tyre_pressure_actual_` to `tyre_pressure_` so the `required` and `differential` families also drop 0/1 instead of surfacing a misleading reading.

Note: this revisits issue #33. The existing test asserted a `required` of 1 is a plausible 1 bar. Since the field is scaled, a raw 1 is the invalid status code rather than 1 bar, so the test is updated to expect it as a sentinel. Happy to adjust if `required` is encoded differently on some vehicles.

Tested: offline test suite passes.