### PR TITLE
feat(sensor): reconstruct combined range from per-engine components

### DIFF
--- a/custom_components/cupra_eu_data_act/data.py
+++ b/custom_components/cupra_eu_data_act/data.py
@@ -854,6 +854,12 @@ class CuratedSensor:
     # duplicate value slots via find_by_field(prefer_max_value=...), so a lagging
     # report snapshot in the same dataset can't make mileage read low.
     monotonic: bool = False
+    # fields to sum as a fallback when this sensor's own field carries no usable
+    # reading. Some vehicles report a curated total (e.g. combined cruising
+    # range) as an empty slot while still sending its per-engine components, so
+    # the sum of these fields reconstructs the total. The portal value, when
+    # present, always wins over the computed sum.
+    sum_fallback_fields: tuple[str, ...] = ()
 
 
 def curated_translation_key(field_name: str, translation_key: str | None = None) -> str:
@@ -1351,6 +1357,10 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         "measurement",
         icon="mdi:map-marker-distance",
         suggested_display_precision=0,
+        sum_fallback_fields=(
+            "cruising_range_primary_engine",
+            "cruising_range_secondary_engine",
+        ),
     ),
     CuratedSensor(
         "cruising_range_primary_engine",

--- a/custom_components/cupra_eu_data_act/sensor.py
+++ b/custom_components/cupra_eu_data_act/sensor.py
@@ -228,6 +228,29 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
 
         return value
 
+    def _sum_fallback_value(self) -> float | int | None:
+        """Sum the curated sensor's ``sum_fallback_fields`` into a total.
+
+        Used when the sensor's own field carries no usable reading. Only usable
+        numeric components contribute; returns ``None`` when none are present so
+        the sensor stays unknown rather than reporting a misleading zero.
+        """
+        points = self.coordinator.data or {}
+        total = 0.0
+        found = False
+        for fname in self._curated.sum_fallback_fields:
+            dp = find_by_field(points, fname)
+            if dp is None or not is_usable_reading(dp.value, fname):
+                continue
+            try:
+                total += float(dp.value)
+            except (TypeError, ValueError):
+                continue
+            found = True
+        if not found:
+            return None
+        return int(total) if total.is_integer() else total
+
     def _source_datapoint(self) -> DataPoint | None:
         """Return the portal data point backing ``native_value``."""
         points = self.coordinator.data or {}
@@ -294,6 +317,16 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
             field_name,
             prefer_max_value=self._curated.monotonic,
         )
+
+        # When the portal sends this field empty (e.g. combined cruising range on
+        # PHEVs) but still reports its components, reconstruct the total from the
+        # declared fallback fields. A usable portal value always takes precedence.
+        if self._curated.sum_fallback_fields and (
+            dp is None or not is_usable_reading(dp.value, field_name)
+        ):
+            summed = self._sum_fallback_value()
+            if summed is not None:
+                return self._sticky(summed)
 
         if not dp:
             return self._sticky(None)


### PR DESCRIPTION
Some PHEVs leave the combined cruising range slot empty while still reporting `cruising_range_primary_engine` and `cruising_range_secondary_engine`. This adds `CuratedSensor.sum_fallback_fields` so a sensor can declare components to sum when its own field has no usable reading, and `native_value` falls back to that sum. A usable portal value always takes precedence over the computed total.

Tested: offline test suite passes.