### PR TITLE
fix(climate): flat remaining_climate_time is minutes, not seconds

### DIFF
--- a/custom_components/cupra_eu_data_act/data.py
+++ b/custom_components/cupra_eu_data_act/data.py
@@ -1500,13 +1500,17 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         "max_temperature", "Battery max temperature", "temperature", "°C", "measurement"
     ),
     # === Climate ===
+    # Flat PHEV format (issue #18) delivers remaining_climatisation_time as an
+    # integer count of MINUTES, aliased to remaining_climate_time. The dotted
+    # format instead sends a "<seconds>s" string (see the dotted registry entry,
+    # which keeps unit "s"/duration_s). Declare minutes here and skip duration_s
+    # so a flat value of 10 renders as "10 min" rather than "10 s".
     CuratedSensor(
         "remaining_climate_time",
         "Remaining climate time",
         "duration",
-        "s",
+        "min",
         "measurement",
-        transform="duration_s",
     ),
     CuratedSensor(
         "residual_energy_in_percent",

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -93,6 +93,15 @@ def main() -> int:
         data.find_by_field(terramar.points, "plug_state") is not None,
         True,
     )
+    flat_climate = next(
+        s for s in data.CURATED_SENSORS_FLAT if s.field_name == "remaining_climate_time"
+    )
+    check("flat climate time unit = minutes (issue #18)", flat_climate.unit, "min")
+    check("flat climate time has no duration transform", flat_climate.transform, None)
+    dotted_climate = next(
+        s for s in data.CURATED_SENSORS_DOTTED if s.field_name == "remaining_climate_time"
+    )
+    check("dotted climate time unit = seconds", dotted_climate.unit, "s")
     check(
         "charging_power in dataset",
         data.find_by_field(terramar.points, "charging_power").value,


### PR DESCRIPTION
## Symptom

On flat-format PHEVs (eGolf/Passat/SEAT/Cupra), the **Remaining climate time** sensor shows seconds instead of minutes: a portal value of `10` renders as `10 s` when it means `10 min` (60x off).

## Cause

The portal delivers this field differently per format:
- **dotted (ID.x)**: a `"<seconds>s"` string, e.g. `"1800s"` -> seconds.
- **flat (issue #18)**: `remaining_climatisation_time`, an integer count of **minutes** (data dictionary: type int, unit `min`), aliased to `remaining_climate_time`.

The flat curated entry wrongly reused the dotted unit `s` and `duration_s` transform, so the integer minutes were labelled as seconds.

## Fix

- Flat entry: unit `min`, no transform (the value is already in minutes).
- Dotted entry: unchanged (`s`/`duration_s`). No change for ID.x/dotted vehicles.

## Verification

- Real flat dataset: `remaining_climatisation_time = 10` -> native value `10 min`.
- Offline tests pass; three added checks lock the asymmetry (flat = min and no transform, dotted = s).

## Note for existing installs

Because the sensor has device_class `duration`, Home Assistant remembers the per-entity display unit. Installs that already created this sensor as seconds will keep showing the old unit (e.g. `600 s` = 10 min) until the entity is recreated or its unit-of-measurement is reset. New installs are unaffected.