### PR TITLE
feat(maintenance): expose service due dates, keep raw interval sign (drop abs)

### DIFF
--- a/custom_components/cupra_eu_data_act/data.py
+++ b/custom_components/cupra_eu_data_act/data.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from functools import lru_cache
 from pathlib import Path
 
@@ -854,6 +854,8 @@ class CuratedSensor:
     # duplicate value slots via find_by_field(prefer_max_value=...), so a lagging
     # report snapshot in the same dataset can't make mileage read low.
     monotonic: bool = False
+    # create the entity disabled in the registry (the user can enable it)
+    enabled_by_default: bool = True
 
 
 def curated_translation_key(field_name: str, translation_key: str | None = None) -> str:
@@ -861,6 +863,27 @@ def curated_translation_key(field_name: str, translation_key: str | None = None)
     if translation_key:
         return translation_key
     return field_name.replace(".", "_")
+
+
+def maintenance_due_datetime(days_value, now):
+    """Service due date from a signed "days until service" countdown.
+
+    The portal encodes maintenance intervals as a countdown that rises toward 0:
+    a negative value is the number of days remaining (e.g. -127 = due in 127
+    days), zero is the due date, and a positive value is days overdue. Turning it
+    into a timestamp removes the sign ambiguity (HA shows "in 4 months" vs "5
+    days ago") that abs() used to hide.
+
+    ``now`` is a timezone-aware datetime (HA local time); the result is anchored
+    to local midnight so it stays stable between daily portal updates. Returns
+    ``None`` for non-numeric input.
+    """
+    try:
+        days = int(days_value)
+    except (TypeError, ValueError):
+        return None
+    midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    return midnight - timedelta(days=days)
 
 
 @dataclass(frozen=True)
@@ -1680,6 +1703,13 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         icon="mdi:car-convertible",
     ),
     # === Maintenance ===
+    # The portal encodes these intervals as a countdown that rises toward 0:
+    # negative = remaining (e.g. -127 d / -23500 km until service), 0 = due,
+    # positive = overdue. The previous abs() collapsed both states to a positive
+    # number, so an overdue service was indistinguishable from a remaining one.
+    # Keep the raw sign here; the *_due_date sensors below re-express the
+    # time-based intervals as an unambiguous timestamp, so the raw day counters
+    # are disabled by default in favour of those dates.
     CuratedSensor(
         "maintenance_interval__time_until_inspection",
         "Inspection interval",
@@ -1687,8 +1717,8 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         "d",
         "measurement",
         icon="mdi:calendar-clock",
-        transform="abs",
         suggested_display_precision=0,
+        enabled_by_default=False,
     ),
     CuratedSensor(
         "maintenance_interval__time_until_oil_change",
@@ -1697,8 +1727,8 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         "d",
         "measurement",
         icon="mdi:oil",
-        transform="abs",
         suggested_display_precision=0,
+        enabled_by_default=False,
     ),
     CuratedSensor(
         "maintenance_interval_distance_until_inspection",
@@ -1707,7 +1737,6 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         "km",
         "measurement",
         icon="mdi:car-wrench",
-        transform="abs",
         suggested_display_precision=0,
     ),
     CuratedSensor(
@@ -1717,8 +1746,24 @@ CURATED_SENSORS_FLAT: tuple[CuratedSensor, ...] = (
         "km",
         "measurement",
         icon="mdi:oil",
-        transform="abs",
         suggested_display_precision=0,
+    ),
+    # Time-based intervals re-expressed as a concrete due date, derived from the
+    # signed day countdown above (see maintenance_due_datetime and the
+    # ".due_date" handling in sensor.py).
+    CuratedSensor(
+        "maintenance_interval__time_until_inspection.due_date",
+        "Inspection due",
+        "timestamp",
+        translation_key="inspection_due_date",
+        icon="mdi:calendar-clock",
+    ),
+    CuratedSensor(
+        "maintenance_interval__time_until_oil_change.due_date",
+        "Oil change due",
+        "timestamp",
+        translation_key="oil_change_due_date",
+        icon="mdi:oil",
     ),
     # === Trip Statistics - Long Term ===
     CuratedSensor(

--- a/custom_components/cupra_eu_data_act/sensor.py
+++ b/custom_components/cupra_eu_data_act/sensor.py
@@ -35,6 +35,7 @@ from .data import (
     is_usable_reading,
     last_connected_time,
     latest_captured_time,
+    maintenance_due_datetime,
     resolve_distance_unit,
     resolve_distance_unit_from_companion_fields,
     resolve_primary_range_unit,
@@ -150,6 +151,15 @@ async def async_setup_entry(
                     new_entities.append(EudaCuratedSensor(coordinator, curated))
                     added_curated.add(curated.field_name)
                 continue
+            # Due-date sensors derive a timestamp from a ".due_date" base field
+            # (e.g. maintenance_interval__time_until_inspection.due_date); create
+            # once the base day-countdown field is present.
+            if curated.field_name.endswith(".due_date"):
+                base_field = curated.field_name[: -len(".due_date")]
+                if find_by_field(points, base_field) is not None:
+                    new_entities.append(EudaCuratedSensor(coordinator, curated))
+                    added_curated.add(curated.field_name)
+                continue
             # Timestamp sensors track ".timestamp" on a base field (e.g.
             # mileage.value.timestamp). Create once the base mileage field is
             # present — timestampUtc is often missing on Cupra/MEB payloads.
@@ -198,6 +208,8 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
             self._attr_state_class = SensorStateClass(curated.state_class)
         if curated.suggested_display_precision is not None:
             self._attr_suggested_display_precision = curated.suggested_display_precision
+        if not curated.enabled_by_default:
+            self._attr_entity_registry_enabled_default = False
 
     def _apply_transform(self, value):
         """Apply configured transform to the raw value."""
@@ -262,6 +274,13 @@ class EudaCuratedSensor(EudaEntity, SensorEntity):
 
     @property
     def native_value(self):
+        if self._curated.field_name.endswith(".due_date"):
+            base_field = self._curated.field_name[: -len(".due_date")]
+            dp = find_by_field(self.coordinator.data or {}, base_field)
+            if dp is None or not is_usable_reading(dp.value, base_field):
+                return self._sticky(None)
+            return self._sticky(maintenance_due_datetime(dp.value, dt_util.now()))
+
         if ".timestamp" in self._curated.field_name:
             base_field = self._curated.field_name.replace(".timestamp", "")
             dp = find_by_field(self.coordinator.data or {}, base_field)

--- a/custom_components/cupra_eu_data_act/strings.json
+++ b/custom_components/cupra_eu_data_act/strings.json
@@ -320,6 +320,12 @@
       "maintenance_interval_distance_until_oil_change": {
         "name": "Oil change distance"
       },
+      "inspection_due_date": {
+        "name": "Inspection due"
+      },
+      "oil_change_due_date": {
+        "name": "Oil change due"
+      },
       "long_term_data_mileage": {
         "name": "Trip distance (long)"
       },

--- a/custom_components/cupra_eu_data_act/translations/de.json
+++ b/custom_components/cupra_eu_data_act/translations/de.json
@@ -320,6 +320,12 @@
       "maintenance_interval_distance_until_oil_change": {
         "name": "Ölwechsel (Strecke)"
       },
+      "inspection_due_date": {
+        "name": "Nächste Inspektion"
+      },
+      "oil_change_due_date": {
+        "name": "Nächster Ölwechsel"
+      },
       "long_term_data_mileage": {
         "name": "Strecke (Langzeit)"
       },

--- a/custom_components/cupra_eu_data_act/translations/en.json
+++ b/custom_components/cupra_eu_data_act/translations/en.json
@@ -320,6 +320,12 @@
       "maintenance_interval_distance_until_oil_change": {
         "name": "Oil change distance"
       },
+      "inspection_due_date": {
+        "name": "Inspection due"
+      },
+      "oil_change_due_date": {
+        "name": "Oil change due"
+      },
       "long_term_data_mileage": {
         "name": "Trip distance (long)"
       },

--- a/custom_components/cupra_eu_data_act/translations/fr.json
+++ b/custom_components/cupra_eu_data_act/translations/fr.json
@@ -320,6 +320,12 @@
       "maintenance_interval_distance_until_oil_change": {
         "name": "Distance vidange"
       },
+      "inspection_due_date": {
+        "name": "Prochaine inspection"
+      },
+      "oil_change_due_date": {
+        "name": "Prochaine vidange"
+      },
       "long_term_data_mileage": {
         "name": "Distance trajet (long)"
       },

--- a/custom_components/cupra_eu_data_act/translations/it.json
+++ b/custom_components/cupra_eu_data_act/translations/it.json
@@ -320,6 +320,12 @@
       "maintenance_interval_distance_until_oil_change": {
         "name": "Distanza cambio olio"
       },
+      "inspection_due_date": {
+        "name": "Prossima ispezione"
+      },
+      "oil_change_due_date": {
+        "name": "Prossimo cambio olio"
+      },
       "long_term_data_mileage": {
         "name": "Distanza viaggio (lungo)"
       },

--- a/custom_components/cupra_eu_data_act/translations/nl.json
+++ b/custom_components/cupra_eu_data_act/translations/nl.json
@@ -320,6 +320,12 @@
       "maintenance_interval_distance_until_oil_change": {
         "name": "Oliebeurt (afstand)"
       },
+      "inspection_due_date": {
+        "name": "Volgende inspectie"
+      },
+      "oil_change_due_date": {
+        "name": "Volgende oliebeurt"
+      },
       "long_term_data_mileage": {
         "name": "Afstand rit (lang)"
       },

--- a/tests/test_offline.py
+++ b/tests/test_offline.py
@@ -93,6 +93,29 @@ def main() -> int:
         data.find_by_field(terramar.points, "plug_state") is not None,
         True,
     )
+    print("maintenance intervals:")
+    from datetime import datetime, timezone
+    _flat = {s.field_name: s for s in data.CURATED_SENSORS_FLAT}
+    _insp = _flat["maintenance_interval__time_until_inspection"]
+    check("inspection interval keeps raw sign (no abs)", _insp.transform, None)
+    check("inspection day counter disabled by default", _insp.enabled_by_default, False)
+    _insp_dist = _flat["maintenance_interval_distance_until_inspection"]
+    check("inspection distance keeps raw sign (no abs)", _insp_dist.transform, None)
+    _due = _flat["maintenance_interval__time_until_inspection.due_date"]
+    check("inspection due is a timestamp", _due.device_class, "timestamp")
+    check("inspection due enabled by default", _due.enabled_by_default, True)
+    _now = datetime(2026, 6, 26, 11, 0, tzinfo=timezone.utc)
+    check(
+        "remaining -127 d -> due date +127 d",
+        data.maintenance_due_datetime(-127, _now).date().isoformat(),
+        "2026-10-31",
+    )
+    check(
+        "overdue +5 d -> due date 5 d ago",
+        data.maintenance_due_datetime(5, _now).date().isoformat(),
+        "2026-06-21",
+    )
+    check("non-numeric due date -> None", data.maintenance_due_datetime("x", _now), None)
     check(
         "charging_power in dataset",
         data.find_by_field(terramar.points, "charging_power").value,


### PR DESCRIPTION
## Problem

The four maintenance interval sensors apply `transform="abs"`, which destroys the sign that tells whether a service is still due or already overdue.

The portal value is a countdown, not a magnitude. From the data dictionary:

> `maintenance_interval__time_until_inspection`: *"Indicates the time remaining until the next service; if this limit was exceeded, this value indicates the time that has passed since then."*
>
> `maintenance_interval_distance_until_inspection`: *"Indicates the remaining running distance until the next service; if this limit was exceeded, this value indicates the distance that has been driven since then (always in km)."*

So **negative = remaining, 0 = due, positive = overdue**. Captured data from one flat-PHEV vehicle confirms it is a live countdown rising toward 0:

| Date | time_until_inspection | time_until_oil_change | distance_until_* |
|---|---|---|---|
| 2026-06-23 | -130 | -495 | -23500 |
| 2026-06-24 | -129 | -494 | -23500 |
| 2026-06-25 | -128 | -493 | -23500 |
| 2026-06-26 | -127 | -492 | -23500 |

The day counters rise by +1/day toward 0 (inspection due in ~127 days). With `abs`, both a remaining `-127` and an overdue `+5` render as a positive number, so an overdue service is indistinguishable from a healthy one, the opposite of what a maintenance sensor should convey.

## Fix

- **Drop `abs`** on all four sensors so the raw sign is preserved (negative = remaining, positive = overdue).
- **Add two `timestamp` sensors**, *Inspection due* / *Oil change due*, derived from the signed day countdown via `maintenance_due_datetime()` (anchored to local midnight). HA then shows an unambiguous date: a future date while remaining, a past date once overdue. With the data above, *Inspection due* = `2026-10-31`.
- **Disable the raw day counters by default** in favour of those dates; the distance counters stay enabled and keep their raw sign (no date is derivable from km).
- New `CuratedSensor.enabled_by_default` flag drives registry enablement; discovery mirrors the existing `.timestamp` derived-sensor pattern.

## Verification

- Offline tests cover sign preservation (transform is `None`), the new timestamp sensors (device_class, enabled-by-default), and the date math (`-127` -> `2026-10-31`, overdue `+5` -> past, non-numeric -> `None`).
- `py_compile` clean; all six translation files validated.

## Note for existing installs

The day counters were always positive (via `abs`) and now read negative (remaining). The new date sensors are the recommended replacement. Recreating the device picks up the new defaults cleanly.